### PR TITLE
NullReferenceException when handling arrays

### DIFF
--- a/JUST.net/JsonTransformer.cs
+++ b/JUST.net/JsonTransformer.cs
@@ -62,13 +62,10 @@ namespace JUST
                 {
                     JArray arrayToken = childToken as JArray;
 
-                    List<object> itemsToAdd = null;
+                    List<object> itemsToAdd = new List<object>();
 
                     foreach (JToken arrEl in childToken.Children())
                     {
-                        if (itemsToAdd == null)
-                            itemsToAdd = new List<object>();
-
                         object itemToAdd = arrEl.Value<JToken>();
 
                         if (arrEl.Type == JTokenType.String && arrEl.ToString().Trim().StartsWith("#"))


### PR DESCRIPTION
When handling arrays, initialize list items to add on declare, to prevent NullReferenceExceptions