### PR TITLE
Register custom functions

### DIFF
--- a/Examples/Transformer_registeredmethods.json
+++ b/Examples/Transformer_registeredmethods.json
@@ -1,0 +1,15 @@
+﻿{
+  "externalStaticMethodResult": "#External_StaticMethod()",
+  "externalStaticTypedParametersResult": "#External_StaticTypedParameters(1,true,abc,2018-10-11T11:00:00.000Z)",
+  "externalInstanceMethodResult": "#External_InstanceMethod()",
+  "externalInstanceTypedParametersResult": "#External_TypedParameters(1,true,abc,2018-10-11T11:00:00.000Z)",
+  "externalInstanceNavigateTypedParametersResult": "#External_NavigateTypedParameters(#valueof($.season.characteristics.hot))",
+
+  "internalStaticMethodResult": "#StaticMethod()",
+  "internalStaticTypedParametersResult": "#StaticTypedParameters(1,true,abc,2018-10-11T11:00:00.000Z)",
+  "internalInstanceMethodResult": "#InstanceMethod()",
+  "internalInstanceTypedParametersResult": "#TypedParameters(1,true,abc,2018-10-11T11:00:00.000Z)",
+  "internalInstanceNavigateTypedParametersResult": "#NavigateTypedParameters(#valueof($.season))",
+
+  "summer": "#ExternalMethods::SeasonsHelper.Season::IsSummer(#valueof($.season.characteristics.hot),#valueof($.season.characteristics.averageDaysOfRain),#valueof($.season.characteristics.randomDay))"
+}

--- a/ExternalMethods/ExternalClass.cs
+++ b/ExternalMethods/ExternalClass.cs
@@ -15,7 +15,7 @@ namespace ExternalMethods
             return "External Instance";
         }
 
-        public string StaticTypedParameters(int n, bool b, string s, DateTime d)
+        public static string StaticTypedParameters(int n, bool b, string s, DateTime d)
         {
             return "External Static TypedParameters success";
         }

--- a/JUST.NET.Test.csproj
+++ b/JUST.NET.Test.csproj
@@ -99,6 +99,9 @@
     <None Include="Examples\Transformer_externalmethods.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Examples\Transformer_registeredmethods.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Examples\Transform_Unordered_2.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/JUST.net/JUSTContext.cs
+++ b/JUST.net/JUSTContext.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace JUST
+{
+    public static class JUSTContext
+    {
+        private static ConcurrentDictionary<string, MethodInfo> _customFunctions = new ConcurrentDictionary<string, MethodInfo>();
+
+        public static void RegisterCustomFunction(string assemblyName, string namespc, string methodName, string methodAlias = null)
+        {
+            var methodInfo = ReflectionHelper.SearchCustomFunction(assemblyName, namespc, methodName);
+            if (methodInfo == null)
+            {
+                throw new Exception("Unable to find specified method!");
+            }
+
+            if (!_customFunctions.TryAdd(methodAlias ?? methodName, methodInfo))
+            {
+                throw new Exception("Error while registering custom method!");
+            }
+        }
+
+        internal static MethodInfo GetCustomMethod(string key)
+        {
+            if (!_customFunctions.TryGetValue(key, out var result))
+            {
+                throw new Exception($"Custom function {key} is not registered!");
+            }
+            return result;
+        }
+
+        public static void ClearCustomFunctionRegistrations()
+        {
+            _customFunctions.Clear();
+        }
+
+        internal static bool IsRegisteredCustomFunction(string name)
+        {
+            return _customFunctions.ContainsKey(name);
+        }
+    }
+}

--- a/JUST.net/JUSTContext.cs
+++ b/JUST.net/JUSTContext.cs
@@ -22,6 +22,16 @@ namespace JUST
             }
         }
 
+        public static bool UnregisterCustomFunction(string name)
+        {
+            return _customFunctions.TryRemove(name, out var removed);
+        }
+
+        public static void ClearCustomFunctionRegistrations()
+        {
+            _customFunctions.Clear();
+        }
+
         internal static MethodInfo GetCustomMethod(string key)
         {
             if (!_customFunctions.TryGetValue(key, out var result))
@@ -29,11 +39,6 @@ namespace JUST
                 throw new Exception($"Custom function {key} is not registered!");
             }
             return result;
-        }
-
-        public static void ClearCustomFunctionRegistrations()
-        {
-            _customFunctions.Clear();
         }
 
         internal static bool IsRegisteredCustomFunction(string name)

--- a/JUST.net/JsonTransformer.cs
+++ b/JUST.net/JsonTransformer.cs
@@ -12,27 +12,6 @@ namespace JUST
 {
     public class JsonTransformer
     {
-        private static ConcurrentDictionary<string, MethodInfo> _customFunctions = new ConcurrentDictionary<string, MethodInfo>();
-
-        public static void RegisterCustomFunction(string assemblyName, string namespc, string methodName, string methodAlias = null)
-        {
-            var methodInfo = ReflectionHelper.SearchCustomFunction(assemblyName, namespc, methodName);
-            if (methodInfo == null)
-            {
-                throw new Exception("Unable to find specified method!");
-            }
-
-            if (!_customFunctions.TryAdd(methodAlias ?? methodName, methodInfo))
-            {
-                throw new Exception("Error while registering custom method!");
-            }
-        }
-
-        public static void ClearCustomFunctionRegistrations()
-        {
-            _customFunctions.Clear();
-        }
-
         public static string Transform(string transformerJson, string inputJson)
         {
             JToken result = null;
@@ -627,8 +606,9 @@ namespace JUST
                     output = ReflectionHelper.caller(null, "JUST.Transformer", functionName, new object[] { array, currentArrayElement, arguments[0] });
                 else if (functionName == "customfunction")
                     output = CallCustomFunction(parameters);
-                else if (_customFunctions.TryGetValue(functionName, out var methodInfo))
+                else if (JUSTContext.IsRegisteredCustomFunction(functionName))
                 {
+                    var methodInfo = JUSTContext.GetCustomMethod(functionName);
                     output = ReflectionHelper.InvokeCustomMethod(methodInfo, parameters, true);
                 }
                 else if (Regex.IsMatch(functionName, ReflectionHelper.EXTERNAL_ASSEMBLY_REGEX)){

--- a/JUST.net/ReflectionHelper.cs
+++ b/JUST.net/ReflectionHelper.cs
@@ -71,7 +71,7 @@ namespace JUST
 
                 //SingleOrDefault fails, dll registrated twice????
                 //Possible alternative to AppDomain: https://github.com/dotnet/coreclr/issues/14680
-                var assembly = assemblies.FirstOrDefault(a => a.ManifestModule.Name == assemblyFileName);   
+                var assembly = assemblies.FirstOrDefault(a => a.ManifestModule.Name == assemblyFileName);
                 if (assembly == null)
                 {
                     var assemblyLocation = Path.Combine(Directory.GetCurrentDirectory(), assemblyFileName);

--- a/JUST.net/ReflectionHelper.cs
+++ b/JUST.net/ReflectionHelper.cs
@@ -12,11 +12,18 @@ namespace JUST
     {
         internal const string EXTERNAL_ASSEMBLY_REGEX = "([\\w.]+)[:]{2}([\\w.]+)[:]{0,2}([\\w.]*)";
 
-        internal static object caller(Assembly assembly, String myclass, String mymethod, object[] parameters, bool convertParameters = false)
+        internal static object caller(Assembly assembly, string myclass, string mymethod, object[] parameters, bool convertParameters = false)
         {
             Type type = assembly?.GetType(myclass) ?? Type.GetType(myclass);
             MethodInfo methodInfo = type.GetTypeInfo().GetMethod(mymethod);
             var instance = !methodInfo.IsStatic ? Activator.CreateInstance(type) : null;
+
+            return InvokeCustomMethod(methodInfo, parameters, convertParameters);
+        }
+
+        internal static object InvokeCustomMethod(MethodInfo methodInfo, object[] parameters, bool convertParameters = false)
+        {
+            var instance = !methodInfo.IsStatic ? Activator.CreateInstance(methodInfo.DeclaringType) : null;
 
             var typedParameters = new List<object>();
             if (convertParameters)
@@ -48,13 +55,23 @@ namespace JUST
             throw new MissingMethodException((assemblyName != null ? $"{assemblyName}." : string.Empty) + $"{namespc}.{methodName}");
         }
 
+        internal static MethodInfo SearchCustomFunction(string assemblyName, string namespc, string methodName)
+        {
+            var assembly = GetAssembly(assemblyName != null, assemblyName, namespc, methodName);
+            Type type = assembly?.GetType(namespc) ?? Type.GetType(namespc);
+            return type?.GetTypeInfo().GetMethod(methodName);
+        }
+
         private static Assembly GetAssembly(bool isAssemblyDefined, string assemblyName, string namespc, string methodName)
         {
             var assemblies = AppDomain.CurrentDomain.GetAssemblies();
             if (isAssemblyDefined)
             {
                 var assemblyFileName = !assemblyName.EndsWith(".dll") ? $"{assemblyName}.dll" : assemblyName;
-                var assembly = assemblies.SingleOrDefault(a => a.ManifestModule.Name == assemblyFileName);
+
+                //SingleOrDefault fails, dll registrated twice????
+                //Possible alternative to AppDomain: https://github.com/dotnet/coreclr/issues/14680
+                var assembly = assemblies.FirstOrDefault(a => a.ManifestModule.Name == assemblyFileName);   
                 if (assembly == null)
                 {
                     var assemblyLocation = Path.Combine(Directory.GetCurrentDirectory(), assemblyFileName);

--- a/Program.cs
+++ b/Program.cs
@@ -208,17 +208,17 @@ namespace JUST.NET.Test
             Console.WriteLine("################################################################################################");
 
             transformer = File.ReadAllText("Examples/Transformer_registeredmethods.json");
-            JsonTransformer.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "StaticMethod", "External_StaticMethod");
-            JsonTransformer.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "StaticTypedParameters", "External_StaticTypedParameters");
-            JsonTransformer.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "InstanceMethod", "External_InstanceMethod");
-            JsonTransformer.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "TypedParameters", "External_TypedParameters");
-            JsonTransformer.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "NavigateTypedParameters", "External_NavigateTypedParameters");
+            JUSTContext.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "StaticMethod", "External_StaticMethod");
+            JUSTContext.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "StaticTypedParameters", "External_StaticTypedParameters");
+            JUSTContext.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "InstanceMethod", "External_InstanceMethod");
+            JUSTContext.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "TypedParameters", "External_TypedParameters");
+            JUSTContext.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "NavigateTypedParameters", "External_NavigateTypedParameters");
 
-            JsonTransformer.RegisterCustomFunction(null, "InternalMethods.InternalClass", "StaticMethod");
-            JsonTransformer.RegisterCustomFunction(null, "InternalMethods.InternalClass", "StaticTypedParameters");
-            JsonTransformer.RegisterCustomFunction(null, "InternalMethods.InternalClass", "InstanceMethod");
-            JsonTransformer.RegisterCustomFunction(null, "InternalMethods.InternalClass", "TypedParameters");
-            JsonTransformer.RegisterCustomFunction(null, "InternalMethods.InternalClass", "NavigateTypedParameters");
+            JUSTContext.RegisterCustomFunction(null, "InternalMethods.InternalClass", "StaticMethod");
+            JUSTContext.RegisterCustomFunction(null, "InternalMethods.InternalClass", "StaticTypedParameters");
+            JUSTContext.RegisterCustomFunction(null, "InternalMethods.InternalClass", "InstanceMethod");
+            JUSTContext.RegisterCustomFunction(null, "InternalMethods.InternalClass", "TypedParameters");
+            JUSTContext.RegisterCustomFunction(null, "InternalMethods.InternalClass", "NavigateTypedParameters");
             
             transformedString = JsonConvert.SerializeObject
                 (JsonTransformer.Transform(JObject.Parse(transformer), JObject.Parse(input)));

--- a/Program.cs
+++ b/Program.cs
@@ -205,6 +205,25 @@ namespace JUST.NET.Test
                 (JsonTransformer.Transform(JArray.Parse(transformer), input));
             Console.WriteLine(transformedString);
 
+            Console.WriteLine("################################################################################################");
+
+            transformer = File.ReadAllText("Examples/Transformer_registeredmethods.json");
+            JsonTransformer.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "StaticMethod", "External_StaticMethod");
+            JsonTransformer.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "StaticTypedParameters", "External_StaticTypedParameters");
+            JsonTransformer.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "InstanceMethod", "External_InstanceMethod");
+            JsonTransformer.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "TypedParameters", "External_TypedParameters");
+            JsonTransformer.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "NavigateTypedParameters", "External_NavigateTypedParameters");
+
+            JsonTransformer.RegisterCustomFunction(null, "InternalMethods.InternalClass", "StaticMethod");
+            JsonTransformer.RegisterCustomFunction(null, "InternalMethods.InternalClass", "StaticTypedParameters");
+            JsonTransformer.RegisterCustomFunction(null, "InternalMethods.InternalClass", "InstanceMethod");
+            JsonTransformer.RegisterCustomFunction(null, "InternalMethods.InternalClass", "TypedParameters");
+            JsonTransformer.RegisterCustomFunction(null, "InternalMethods.InternalClass", "NavigateTypedParameters");
+            
+            transformedString = JsonConvert.SerializeObject
+                (JsonTransformer.Transform(JObject.Parse(transformer), JObject.Parse(input)));
+            Console.WriteLine(transformedString);
+
             Console.ReadLine();
         }
     }

--- a/README.md
+++ b/README.md
@@ -728,14 +728,14 @@ Output:-
 You can also call your methods by name, by providing the full path (namespace including class name, method name, assembly if necessary).
 The assembly file doesn't need to be referenced in your program, it only has to exist in the same directory. It will load the assembly into
 the application's default domain, if not loaded yet.
-Here's the syntax:-
 
-#NameSpace.Plus.ClassName::Your_Method_Name(argument1.......,argumentN)
-#AssemblyName::NameSpace.Plus.ClassName::Your_Method_Name(argument1.......,argumentN)
+Here's the syntax:
+`#NameSpace.Plus.ClassName::Your_Method_Name(argument1.......,argumentN)`
+`#AssemblyName::NameSpace.Plus.ClassName::Your_Method_Name(argument1.......,argumentN)`
 
-Consider the following input:-
-
-``{
+Consider the following input:
+```
+{
   "season": {
     "characteristics": {
       "hot": true,
@@ -743,7 +743,21 @@ Consider the following input:-
       "randomDay": "2018-08-01T00:00:00.000Z"
     }
   }
-}``
+}
+```
+
+Transformer:
+
+```
+{
+  "summer": "#ExternalMethods::SeasonsHelper.Season::IsSummer(#valueof($.season.characteristics.hot),#valueof($.season.characteristics.averageDaysOfRain),#valueof($.season.characteristics.randomDay))"
+}
+```
+
+Output:
+```
+{"summer": true}
+```
 
 ## Register User Defined methods for seamless use
 
@@ -756,8 +770,8 @@ After registration you can call it like any other built-in function.
 
 The registrations are handled in a static property, so they will live as long as your application lives.
 You have the possibility to unregister a custom function or remove all registrations with the following methods:
-``JUSTContext.UnregisterCustomFunction(name)
-JUSTContext.ClearCustomFunctionRegistrations()``
+`JUSTContext.UnregisterCustomFunction(name)`
+`JUSTContext.ClearCustomFunctionRegistrations()`
 
 Consider the following input:-
 
@@ -773,20 +787,19 @@ Consider the following input:-
 }
 ```
 
-Registration:-
-
+Registration:
 ```
 JsonTransformer.RegisterCustomFunction("SomeAssemblyName", "NameSpace.Plus.ClassName", "IsSummer");
 ```
 
-Transformer:-
-
+Transformer:
 ```
 {
   "summer": "#IsSummer(#valueof($.season.characteristics.hot),#valueof($.season.characteristics.averageDaysOfRain),#valueof($.season.characteristics.randomDay))"
-}```
+}
+```
 
-Output:-
+Output:
 ```
 {"summer": true}
 ```

--- a/README.md
+++ b/README.md
@@ -745,10 +745,39 @@ Consider the following input:-
   }
 }``
 
+## Register User Defined methods for seamless use
+
+To reduce the fuzz of calling custom methods, you can register your custom functions by calling this static method: 
+`JUSTContext.RegisterCustomFunction(assemblyName, namespace, methodName, methodAlias)`
+
+Parameter 'namespace' must include the class name as well, 'assemblyName' is optional, so as 'methodAlias', which can be 
+used to register methods with the same name under diferent namespaces.
+After registration you can call it like any other built-in function.
+
+The registrations are handled in a static property, so they will live as long as your application lives.
+You have the possibility to unregister a custom function or remove all registrations with the following methods:
+``JUSTContext.UnregisterCustomFunction(name)
+JUSTContext.ClearCustomFunctionRegistrations()``
+
+Consider the following input:-
+
+``{
+  "season": {
+    "characteristics": {
+      "hot": true,
+      "averageDaysOfRain": 10,
+      "randomDay": "2018-08-01T00:00:00.000Z"
+    }
+  }
+}``
+
+Registration:-
+`JsonTransformer.RegisterCustomFunction("SomeAssemblyName", "NameSpace.Plus.ClassName", "IsSummer");`
+
 Transformer:-
 
 ``{
-  "summer": "#ExternalMethods::SeasonsHelper.Season::IsSummer(#valueof($.season.characteristics.hot),#valueof($.season.characteristics.averageDaysOfRain),#valueof($.season.characteristics.randomDay))"
+  "summer": "#IsSummer(#valueof($.season.characteristics.hot),#valueof($.season.characteristics.averageDaysOfRain),#valueof($.season.characteristics.randomDay))"
 }``
 
 Output:-

--- a/README.md
+++ b/README.md
@@ -761,7 +761,8 @@ JUSTContext.ClearCustomFunctionRegistrations()``
 
 Consider the following input:-
 
-``{
+```
+{
   "season": {
     "characteristics": {
       "hot": true,
@@ -769,19 +770,26 @@ Consider the following input:-
       "randomDay": "2018-08-01T00:00:00.000Z"
     }
   }
-}``
+}
+```
 
 Registration:-
-`JsonTransformer.RegisterCustomFunction("SomeAssemblyName", "NameSpace.Plus.ClassName", "IsSummer");`
+
+```
+JsonTransformer.RegisterCustomFunction("SomeAssemblyName", "NameSpace.Plus.ClassName", "IsSummer");
+```
 
 Transformer:-
 
-``{
+```
+{
   "summer": "#IsSummer(#valueof($.season.characteristics.hot),#valueof($.season.characteristics.averageDaysOfRain),#valueof($.season.characteristics.randomDay))"
-}``
+}```
 
 Output:-
-``{"summer": true}``
+```
+{"summer": true}
+```
 
 ## Complex nested functions
 


### PR DESCRIPTION
#38 
Provide a way to register custom function that will be recognized as built-in functions.
Using a ConcurrentDictionary to keep registered functions.
Possibility to assign an alias to allow registration of methods from different namespaces with the same name.
Update documentation