### PR TITLE
Fix date handling everywhere so it always uses DateParseHandling.None, or honor whatever DefaultSettings are already configured.

### DIFF
--- a/JUST.net/DataTransformer.cs
+++ b/JUST.net/DataTransformer.cs
@@ -200,10 +200,7 @@ namespace JUST
             if (parameters.Length == 3)
                 input = parameters[2];
 
-            JsonReader reader = new JsonTextReader(new StringReader(input));
-            reader.DateParseHandling = DateParseHandling.None;
-            JToken token = JObject.Load(reader);
-           
+            JToken token = JsonConvert.DeserializeObject<JObject>(input);
             JToken selectedToken = token.SelectToken(parameters[0]);
 
             if (selectedToken.Type != JTokenType.Array)

--- a/JUST.net/JsonTransformer.cs
+++ b/JUST.net/JsonTransformer.cs
@@ -480,7 +480,7 @@ namespace JUST
 
             string jsonPath = inputString.Substring(indexOfStart + 1, indexOfEnd - indexOfStart - 1);
 
-            JToken token = JObject.Parse(inputJson);
+            JToken token = JsonConvert.DeserializeObject<JObject>(inputJson);
 
             JToken selectedToken = token.SelectToken(jsonPath);
 
@@ -723,7 +723,7 @@ namespace JUST
         #region Split
         public static IEnumerable<string> SplitJson(string input, string arrayPath)
         {
-            JObject inputJObject = JObject.Parse(input);
+            JObject inputJObject = JsonConvert.DeserializeObject<JObject>(input);
 
             List<JObject> jObjects = SplitJson(inputJObject, arrayPath).ToList<JObject>();
 

--- a/JUST.net/JsonTransformer.cs
+++ b/JUST.net/JsonTransformer.cs
@@ -278,7 +278,6 @@ namespace JUST
                     {
                         string strArrayToken = property.Name.Substring(6, property.Name.Length - 7);
 
-                        JsonReader reader = null;
                         var jsonToLoad = inputJson;
                         if (currentArrayToken != null && property.Name.Contains("#loopwithincontext"))
                         {

--- a/JUST.net/JsonTransformer.cs
+++ b/JUST.net/JsonTransformer.cs
@@ -10,6 +10,17 @@ namespace JUST
 {
     public class JsonTransformer
     {
+        static JsonTransformer()
+        {
+            if (JsonConvert.DefaultSettings == null)
+            {
+                JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+                {
+                    DateParseHandling = DateParseHandling.None
+                };
+            }
+        }
+        
         public static string Transform(string transformerJson, string inputJson)
         {
             JToken result = null;
@@ -268,15 +279,14 @@ namespace JUST
                         string strArrayToken = property.Name.Substring(6, property.Name.Length - 7);
 
                         JsonReader reader = null;
+                        var jsonToLoad = inputJson;
                         if (currentArrayToken != null && property.Name.Contains("#loopwithincontext"))
                         {
                             strArrayToken = property.Name.Substring(19, property.Name.Length - 20);
-                            reader = new JsonTextReader(new StringReader(JsonConvert.SerializeObject(currentArrayToken)));
+                            jsonToLoad = JsonConvert.SerializeObject(currentArrayToken);
                         }
-                        else
-                            reader = new JsonTextReader(new StringReader(inputJson));
-                        reader.DateParseHandling = DateParseHandling.None;
-                        JToken token = JObject.Load(reader);
+                        
+                        JToken token = JsonConvert.DeserializeObject<JObject>(jsonToLoad);
                         JToken arrayToken = null;
                         if (strArrayToken.Contains("#"))
                         {

--- a/JUST.net/JsonValidator.cs
+++ b/JUST.net/JsonValidator.cs
@@ -38,9 +38,9 @@ namespace JUST
             SchemaValidationEventHandler handler = new SchemaValidationEventHandler(HandleEvent);
             if (!string.IsNullOrEmpty(schemaNoPrefix))
             {
-                JObject xSchemaToken = JObject.Parse(schemaNoPrefix);
+                JObject xSchemaToken = JsonConvert.DeserializeObject<JObject>(schemaNoPrefix);
                 JSchema schema = JSchema.Parse(JsonConvert.SerializeObject(xSchemaToken));
-                JObject json = JObject.Parse(inputJsonString);
+                JObject json = JsonConvert.DeserializeObject<JObject>(inputJsonString);
                 try
                 {
                     json.Validate(schema, handler);
@@ -57,10 +57,10 @@ namespace JUST
                 foreach(KeyValuePair<string,string> schemaPair in schemaCollection)
                 {
 
-                    JObject xSchemaToken = JObject.Parse(schemaPair.Value);
+                    JObject xSchemaToken = JsonConvert.DeserializeObject<JObject>(schemaPair.Value);
                     PrefixKey(xSchemaToken, schemaPair.Key);
                     JSchema schema = JSchema.Parse(JsonConvert.SerializeObject(xSchemaToken));
-                    JObject json = JObject.Parse(inputJsonString);
+                    JObject json = JsonConvert.DeserializeObject<JObject>(inputJsonString);
                     try
                     {
                         json.Validate(schema, handler);

--- a/JUST.net/Transformer.cs
+++ b/JUST.net/Transformer.cs
@@ -16,7 +16,7 @@ namespace JUST
             JsonReader reader = new JsonTextReader(new StringReader(inputJson));
             reader.DateParseHandling = DateParseHandling.None;
             JToken token = JObject.Load(reader);
-            //JToken token = JObject.Parse(inputJson);
+            //JToken token = JsonConvert.DeserializeObject<JObject>(inputJson);
 
             JToken selectedToken = token.SelectToken(jsonPath);
             return GetValue(selectedToken);
@@ -544,7 +544,7 @@ namespace JUST
             if (!groupingElement.Contains(":"))
             {
 
-                JObject inObj = JObject.Parse(inputJson);
+                JObject inObj = JsonConvert.DeserializeObject<JObject>(inputJson);
 
                 JArray arr = (JArray)inObj.SelectToken(jsonPath);
 
@@ -556,7 +556,7 @@ namespace JUST
             {
                 string[] groupingElements = groupingElement.Split(':');
 
-                JObject inObj = JObject.Parse(inputJson);
+                JObject inObj = JsonConvert.DeserializeObject<JObject>(inputJson);
 
                 JArray arr = (JArray)inObj.SelectToken(jsonPath);
 

--- a/JUST.net/Transformer.cs
+++ b/JUST.net/Transformer.cs
@@ -13,22 +13,14 @@ namespace JUST
     {
         public static object valueof(string jsonPath, string inputJson)
         {
-            JsonReader reader = new JsonTextReader(new StringReader(inputJson));
-            reader.DateParseHandling = DateParseHandling.None;
-            JToken token = JObject.Load(reader);
-            //JToken token = JsonConvert.DeserializeObject<JObject>(inputJson);
-
+            JToken token = JsonConvert.DeserializeObject<JObject>(inputJson);
             JToken selectedToken = token.SelectToken(jsonPath);
             return GetValue(selectedToken);
         }
 
-
         public static string exists(string jsonPath, string inputJson)
         {
-            JsonReader reader = new JsonTextReader(new StringReader(inputJson));
-            reader.DateParseHandling = DateParseHandling.None;
-            JToken token = JObject.Load(reader);
-
+            JToken token = JsonConvert.DeserializeObject<JObject>(inputJson);
             JToken selectedToken = token.SelectToken(jsonPath);
 
             if (selectedToken != null)
@@ -39,10 +31,7 @@ namespace JUST
 
         public static string existsandnotempty(string jsonPath, string inputJson)
         {
-            JsonReader reader = new JsonTextReader(new StringReader(inputJson));
-            reader.DateParseHandling = DateParseHandling.None;
-            JToken token = JObject.Load(reader);
-
+            JToken token = JsonConvert.DeserializeObject<JObject>(inputJson);
             JToken selectedToken = token.SelectToken(jsonPath);
 
             if (selectedToken != null)


### PR DESCRIPTION
Update Json parsing so that it correctly honors JsonConvert.DefaultSettings everywhere (by always using JsonConvert.DeserializeObject<JObject>, instead of JObject static methods).
Configure DateParseHandling.None everywhere via static constructor, if not already configured elsewhere.