### PR TITLE
Looping over empty object or null value 

### DIFF
--- a/UnitTests/Arrays/LoopingTests.cs
+++ b/UnitTests/Arrays/LoopingTests.cs
@@ -134,5 +134,34 @@ namespace JUST.UnitTests.Arrays
 
             Assert.AreEqual("{\"Colors\":[]}", result);
         }
+
+        [Test]
+        public void EmptyPropertiesLooping()
+        {
+            var input = "{ \"animals\": { } }";
+            var transformer = "{ \"sounds\": { \"#loop($.animals)\": { \"#eval(#currentproperty())\": \"#currentvalueatpath($..sound)\" } } }";
+            var context = new JUSTContext
+            {
+                EvaluationMode = EvaluationMode.Strict
+            };
+            var result = JsonTransformer.Transform(transformer, input, context);
+
+            Assert.AreEqual("{\"sounds\":{}}", result);
+        }
+
+        [Test]
+        public void NullLooping()
+        {
+            var input = "{ \"spell_numbers\": null }";
+            var transformer = "{ \"number_index\": { \"#loop($.spell_numbers)\": { \"#eval(#currentindex())\": \"#currentvalueatpath(#concat($.,#currentproperty()))\" } } }";
+            var context = new JUSTContext
+            {
+                EvaluationMode = EvaluationMode.Strict
+            };
+            var result = JsonTransformer.Transform(transformer, input, context);
+
+            Assert.AreEqual("{\"number_index\":null}", result);
+        }
+        
     }
 }


### PR DESCRIPTION
After #90 looping over an empty object returned an empty array, fixed to return an empty object. When looping over value 'null', 'null' is returned as result.  