### PR TITLE
Fix single array element result when filter array with JsonPath

### DIFF
--- a/JUST.net/JsonTransformer.cs
+++ b/JUST.net/JsonTransformer.cs
@@ -271,6 +271,11 @@ namespace JUST
                         try
                         {
                             arrayToken = token.SelectToken(strArrayToken);
+                            if (Regex.IsMatch(strArrayToken ?? string.Empty, "\\[.+\\]$") && arrayToken.Type != JTokenType.Array)
+                            {
+                                arrayToken = new JArray(arrayToken);
+                            }
+
                             if (arrayToken is IDictionary<string, JToken> dict) //JObject is a dictionary
                             {
                                 isDictionary = true;
@@ -560,7 +565,7 @@ namespace JUST
         {
             try
             {
-                object output = null;
+                object output;
 
                 string functionName, argumentString;
                 if (!ExpressionHelper.TryParseFunctionNameAndArguments(functionString, out functionName, out argumentString))

--- a/UnitTests/Arrays/LoopingTests.cs
+++ b/UnitTests/Arrays/LoopingTests.cs
@@ -134,5 +134,33 @@ namespace JUST.UnitTests.Arrays
 
             Assert.AreEqual("{\"Colors\":[]}", result);
         }
+
+        [Test]
+        public void SingleResultFilter()
+        {
+            var input = "{\"array\":[{\"resource\":\"Location\",\"number\":\"3\" },{\"resource\":\"Organization\",\"number\":\"10\"}] }";
+            var transformer = "{\"result\":{\"#loop($.array[?(@resource=='Location')])\":{\"existsLocation\":true}}}";
+            var context = new JUSTContext
+            {
+                EvaluationMode = EvaluationMode.Strict
+            };
+            var result = JsonTransformer.Transform(transformer, input, context);
+
+            Assert.AreEqual("{\"result\":[{\"existsLocation\":true}]}", result);
+        }
+
+        [Test]
+        public void SingleIndexReference()
+        {
+            var input = "{\"array\":[{\"resource\":\"Location\",\"number\":\"3\" },{\"resource\":\"Organization\",\"number\":\"10\"}] }";
+            var transformer = "{\"result\": {\"#loop($.array[1])\": {\"number\":\"#currentvalueatpath($.number)\"} }}";
+            var context = new JUSTContext
+            {
+                EvaluationMode = EvaluationMode.Strict
+            };
+            var result = JsonTransformer.Transform(transformer, input, context);
+
+            Assert.AreEqual("{\"result\":[{\"number\":\"10\"}]}", result);
+        }
     }
 }


### PR DESCRIPTION
#94
With the introduction of object properties' looping, filtering a single element of an array was assumed as an object instead of an array.