### PR TITLE
Escape reserved characters

### DIFF
--- a/JUST.net/DataTransformer.cs
+++ b/JUST.net/DataTransformer.cs
@@ -121,7 +121,7 @@ namespace JUST
 
                 string argumentString = functionString.Substring(indexOfStart + 1, functionString.Length - indexOfStart - 2);
 
-                string[] arguments = ExpressionHelper.GetArguments(argumentString);
+                string[] arguments = ExpressionHelper.SplitArguments(argumentString);
 
                 List<object> listParameters = new List<object>();
 

--- a/JUST.net/ExpressionHelper.cs
+++ b/JUST.net/ExpressionHelper.cs
@@ -5,7 +5,7 @@ namespace JUST
 {
     internal class ExpressionHelper
     {
-        private const char EscapeChar = '/'; //do not use backslash, it is already the escape char in JSON
+        internal const char EscapeChar = '/'; //do not use backslash, it is already the escape char in JSON
         private const string FunctionAndArgumentsRegex = "^#(.+?)[(](.*)[)]$";
 
         internal static bool TryParseFunctionNameAndArguments(string input, out string functionName, out string arguments)

--- a/JUST.net/JsonTransformer.cs
+++ b/JUST.net/JsonTransformer.cs
@@ -331,6 +331,13 @@ namespace JUST
                         isLoop = true;
                     }
                     /*End looping */
+
+                    if (property.Name != null && property.Value.ToString().StartsWith($"{ExpressionHelper.EscapeChar}#"))
+                    {
+                        var clone = property.Value as JValue;
+                        clone.Value = clone.Value.ToString().Substring(1);
+                        property.Value.Replace(clone);
+                    }
                 }
 
                 if (childToken.Type == JTokenType.String && childToken.Value<string>().Trim().StartsWith("#") 

--- a/JUST.net/JsonTransformer.cs
+++ b/JUST.net/JsonTransformer.cs
@@ -619,7 +619,7 @@ namespace JUST
                         var contextInput = GetInputToken(localContext);
                         var input = JToken.Parse(Transform(parameters[0].ToString(), contextInput.ToString(), localContext));
                         (localContext ?? GlobalContext).Input = input;
-                        output = ParseFunction(parameters[1].ToString().Trim('\''), inputJson, array, currentArrayElement, localContext ?? GlobalContext);
+                        output = ParseFunction(parameters[1].ToString().Trim(' ', '\''), inputJson, array, currentArrayElement, localContext ?? GlobalContext);
                         (localContext ?? GlobalContext).Input = contextInput;
                     }
                     else

--- a/JUST.net/JsonTransformer.cs
+++ b/JUST.net/JsonTransformer.cs
@@ -3,7 +3,6 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace JUST
 {
@@ -518,7 +517,7 @@ namespace JUST
         #region Replace
         private static KeyValuePair<string, JToken> Replace(string arguments, string inputJson, JUSTContext localContext)
         {
-            string[] argumentArr = ExpressionHelper.GetArguments(arguments);
+            string[] argumentArr = ExpressionHelper.SplitArguments(arguments);
             if (argumentArr.Length < 2)
             {
                 throw new Exception("Function #replace needs two arguments - 1. jsonPath to be replaced, 2. token to replace with.");
@@ -562,9 +561,8 @@ namespace JUST
                     return functionName;
                 }
 
-                string[] arguments = ExpressionHelper.GetArguments(argumentString);
-                var listParameters = new List<object>();
-
+                string[] arguments = ExpressionHelper.SplitArguments(argumentString);
+                
                 if (functionName == "ifcondition")
                 {
                     var condition = ParseArgument(inputJson, array, currentArrayElement, arguments[0], localContext);
@@ -574,6 +572,7 @@ namespace JUST
                 }
                 else
                 {
+                    var listParameters = new List<object>();
                     int i = 0;
                     for (; i < (arguments?.Length ?? 0); i++)
                     {
@@ -603,7 +602,7 @@ namespace JUST
                         var methodInfo = GlobalContext.GetCustomMethod(functionName);
                         output = ReflectionHelper.InvokeCustomMethod(methodInfo, parameters, true, localContext ?? GlobalContext);
                     }
-                    else if (Regex.IsMatch(functionName, ReflectionHelper.EXTERNAL_ASSEMBLY_REGEX))
+                    else if (ReflectionHelper.IsExternalFunction(functionName))
                     {
                         output = ReflectionHelper.CallExternalAssembly(functionName, parameters, localContext ?? GlobalContext);
                     }
@@ -639,23 +638,16 @@ namespace JUST
             }
             catch (Exception ex)
             {
+                //TODO Exception with full function string and specific function string (first and last level of recursion)
                 throw new Exception("Error while calling function : " + functionString + " - " + ex.Message, ex);
             }
         }
 
         private static object ParseArgument(string inputJson, JArray array, JToken currentArrayElement, string argument, JUSTContext localContext)
         {
-            string trimmedArgument = argument;
-
-            if (argument.Contains("#"))
-                trimmedArgument = argument.Trim();
-
-            if (trimmedArgument.StartsWith("#"))
-            {
-                return ParseFunction(trimmedArgument, inputJson, array, currentArrayElement, localContext);
-            }
-            else
-                return trimmedArgument;
+            return ExpressionHelper.IsFunction(argument) ?
+                ParseFunction(argument.Trim(), inputJson, array, currentArrayElement, localContext)
+                : ExpressionHelper.UnescapeSharp(argument);
         }
 
         private static object CallCustomFunction(object[] parameters, JUSTContext localContext)

--- a/JUST.net/ReflectionHelper.cs
+++ b/JUST.net/ReflectionHelper.cs
@@ -12,7 +12,7 @@ namespace JUST
 {
     internal static class ReflectionHelper
     {
-        internal const string EXTERNAL_ASSEMBLY_REGEX = "([\\w.]+)[:]{2}([\\w.]+)[:]{0,2}([\\w.]*)";
+        private const string EXTERNAL_ASSEMBLY_REGEX = "([\\w.]+)[:]{2}([\\w.]+)[:]{0,2}([\\w.]*)";
 
         internal static object caller(Assembly assembly, string myclass, string mymethod, object[] parameters, bool convertParameters, JUSTContext context)
         {
@@ -202,6 +202,11 @@ namespace JUST
                 return Activator.CreateInstance(t);
 
             return null;
+        }
+
+        internal static bool IsExternalFunction(string functionName)
+        {
+            return Regex.IsMatch(functionName, EXTERNAL_ASSEMBLY_REGEX);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1182,7 +1182,7 @@ Output:
 
 ## Escaping reserved characters
 
-Characters like '(' and ')' (curved brackets), and ',' (comma) are considered reserved characters when used within a function (not on a regular string). Also '#' (sharp) is a reserved character when used at the start of a statement (value of property or argument of a function). To avoid parsing these characters as reserved characters you may "escape" them, adding a '/' (slash) before the reserved character. For '#', it is only necessary to escape when it occurs at the start of a statement.
+Characters like '(' and ')' (round brackets), and ',' (comma) are considered reserved characters when used within a function (not on a regular string). Also '#' (sharp) is a reserved character when used at the start of a statement (value of property or argument of a function). To avoid parsing these characters as reserved characters you may "escape" them, adding a '/' (slash) before the reserved character. For '#', it is only necessary to escape when it occurs at the start of a statement.
 This is especially useful when creating dynamic expressions.
 
 Consider the following input:

--- a/README.md
+++ b/README.md
@@ -1179,6 +1179,52 @@ Output:
 }
 ```
 
+
+## Escaping reserved characters
+
+Characters like '(' and ')' (curved brackets), and ',' (comma) are considered reserved characters when used within a function (not on a regular string). Also '#' (sharp) is a reserved character when used at the start of a statement (value of property or argument of a function). To avoid parsing these characters as reserved characters you may "escape" them, adding a '/' (slash) before the reserved character. For '#', it is only necessary to escape when it occurs at the start of a statement.
+This is especially useful when creating dynamic expressions.
+
+Consider the following input:
+
+```JSON
+{
+  "arg": 1,
+  "arr": [{
+	"id": 1,
+	"val": 100
+  },{
+	"id": 2,
+	"val": 200
+  }]
+}
+```
+
+Transformer:
+
+```JSON
+{
+  "sharp": "/#not_a_function",
+  "sharp_arg": "#xconcat(/#not,_a_function_arg)",
+  "parentheses": "#xconcat(func/(',#valueof($.arg),'/))", 
+  "comma": "#xconcat(func/(',#valueof($.arg),'/,'other_value'/))",
+  "dynamic_expr": "#valueof(#xconcat($.arr[?/(@.id==,#valueof($.arg),/)].val))"
+}
+```
+
+
+Output:
+```JSON
+{
+  "sharp": "#not_a_function",
+  "sharp_arg": "#not_a_function_arg",
+  "parentheses": "func('1')", 
+  "comma": "func('1','other_value')",
+  "dynamic_expr": 100
+}
+```
+
+
 ## Check for existance 
 
 The following two functions have been added to check for existance:

--- a/UnitTests/ArgumentsEscapeTests.cs
+++ b/UnitTests/ArgumentsEscapeTests.cs
@@ -26,16 +26,6 @@ namespace JUST.UnitTests
             Assert.AreEqual("{\"result\":\"()#\"}", result);
         }
 
-        //[Test]
-        //public void EscapedSingleQuotes()
-        //{
-        //    var args = $"{EscapeChar}'{EscapeChar}'";
-        //    var transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
-        //    var result = JsonTransformer.Transform(transformer, "{}");
-
-        //    Assert.AreEqual("{\"result\":\"''#\"}", result);
-        //}
-
         [Test]
         public void EscapedComma()
         {
@@ -56,18 +46,6 @@ namespace JUST.UnitTests
             Assert.AreEqual($"{{\"result\":\"##\"}}", result);
         }
 
-        //[Test]
-        //public void QuotedArgument()
-        //{
-        //    const string args = "'arg1,#func(arg2.1,arg2.2)'";
-        //    const string input = "{ \"test\": \"" + args + "\" }";
-
-        //    const string transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
-        //    var result = JsonTransformer.Transform(transformer, input);
-
-        //    Assert.AreEqual("{\"result\":\"arg1,#func(arg2.1,arg2.2)#\"}", result);
-        //}
-
         [Test]
         public void NestedFunctionEscapedArguments()
         {
@@ -85,7 +63,6 @@ namespace JUST.UnitTests
         {
             const string args = "arg1" +
                 ",#xconcat(arg2.1,#constant_comma(),#xconcat(arg2.3.1,#constant_hash(),arg2.3.3),#add(1,2))" +
-                //",'arg3.1,arg3.2,func(arg3.3.1,arg3.3.2)'" +
                 ",arg4/(.1/)" +
                 ",arg5/,";
             const string input = "{ \"test\": \"" + args + "\" }";
@@ -93,7 +70,7 @@ namespace JUST.UnitTests
             const string transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
             var result = JsonTransformer.Transform(transformer, input);
 
-            Assert.AreEqual("{\"result\":\"arg1arg2.1,arg2.3.1#arg2.3.33" /*+ "arg3.1,arg3.2,func(arg3.3.1,arg3.3.2)"*/ + "arg4(.1)arg5,#\"}", result);
+            Assert.AreEqual("{\"result\":\"arg1arg2.1,arg2.3.1#arg2.3.33arg4(.1)arg5,#\"}", result);
         }
 
         [Test]
@@ -102,18 +79,6 @@ namespace JUST.UnitTests
             const string transformer = "{ \"result\": \"#xconcat(///),_end)\" }";
             var result = JsonTransformer.Transform(transformer, "{}");
             Assert.AreEqual("{\"result\":\"/)_end\"}",result);
-        }
-
-        [Test]
-        public void TestIssue59()
-        {
-            const string input = "{\"PhoneTypeToSearch\": \"iPhone\",\"Address\": [{\"City\": \"NewYork\",\"name\": \"Jim\"},{\"City\": \"NewYork\",\"name\": \"John\"}],\"people\": [{\"name\": \"Jim\",\"phoneNumbers\": [{\"type\": \"iPhone\",\"number\": \"0123-4567-8888\",\"countryPrefix\": \"34\"},{\"type\": \"work\",\"number\": \"012567-8910\"}]},{\"name\": \"John\",\"phoneNumbers\": [{\"type\": \"iPhone\",\"number\": \"0123-4562347-8888\",\"countryPrefix\": \"43\"},{\"type\": \"home\",\"number\": \"0134523-4567-8910\"}]},{\"name\": \"John\"}]}";
-
-            const string transformer = "{ \"Persons\": { \"#loop($.people)\": { \"Address\": \"#valueof(#xconcat($.Address[?,/(@.name==',#currentvalueatpath($.name),'/)]))\" } }}";
-
-            var result = JsonTransformer.Transform(transformer, input);
-
-            Assert.AreEqual("{\"Persons\":[{\"Address\":{\"City\":\"NewYork\",\"name\":\"Jim\"}},{\"Address\":{\"City\":\"NewYork\",\"name\":\"John\"}},{\"Address\":{\"City\":\"NewYork\",\"name\":\"John\"}}]}", result);
         }
     }
 }

--- a/UnitTests/ArgumentsEscapeTests.cs
+++ b/UnitTests/ArgumentsEscapeTests.cs
@@ -1,0 +1,119 @@
+﻿using NUnit.Framework;
+
+namespace JUST.UnitTests
+{
+    [TestFixture]
+    public class ArgumentsEscapeTests
+    {
+        private const string EscapeChar = "/";
+        [Test]
+        public void NoEscapedCharacters()
+        {
+            const string args = "arg1";
+            const string transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
+            var result = JsonTransformer.Transform(transformer, "{}");
+
+            Assert.AreEqual("{\"result\":\"arg1#\"}", result);
+        }
+
+        [Test]
+        public void EscapedBrackets()
+        {
+            var args = $"{EscapeChar}({EscapeChar})";
+            var transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
+            var result = JsonTransformer.Transform(transformer, "{}");
+
+            Assert.AreEqual("{\"result\":\"()#\"}", result);
+        }
+
+        [Test]
+        public void EscapedSingleQuotes()
+        {
+            var args = $"{EscapeChar}'{EscapeChar}'";
+            var transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
+            var result = JsonTransformer.Transform(transformer, "{}");
+
+            Assert.AreEqual("{\"result\":\"''#\"}", result);
+        }
+
+        [Test]
+        public void EscapedComma()
+        {
+            var args = $"{EscapeChar},";
+            var transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
+            var result = JsonTransformer.Transform(transformer, "{}");
+
+            Assert.AreEqual("{\"result\":\",#\"}", result);
+        }
+
+        [Test]
+        public void EscapedSharp()
+        {
+            var args = $"{EscapeChar}#";
+            var transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
+            var result = JsonTransformer.Transform(transformer, "{}");
+
+            Assert.AreEqual($"{{\"result\":\"##\"}}", result);
+        }
+
+        [Test]
+        public void QuotedArgument()
+        {
+            const string args = "'arg1,#func(arg2.1,arg2.2)'";
+            const string input = "{ \"test\": \"" + args + "\" }";
+
+            const string transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
+            var result = JsonTransformer.Transform(transformer, input);
+
+            Assert.AreEqual("{\"result\":\"arg1,#func(arg2.1,arg2.2)#\"}", result);
+        }
+
+        [Test]
+        public void NestedFunctionEscapedArguments()
+        {
+            const string args = "#arg1,#xconcat(/#notfunc/(/), #constant_comma(),#xconcat(/,arg2.3.1,#constant_hash(),/'arg2.3.3),/,,#add(3,2))";
+            const string input = "{ \"test\": \"" + args + "\" }";
+
+            const string transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
+            var result = JsonTransformer.Transform(transformer, input);
+
+            Assert.AreEqual("{\"result\":\"#arg1#notfunc(),,arg2.3.1#'arg2.3.3,5#\"}", result);
+        }
+
+        [Test]
+        public void MixedArguments()
+        {
+            const string args = "arg1" +
+                ",#xconcat(arg2.1,#constant_comma(),#xconcat(arg2.3.1,#constant_hash(),arg2.3.3),#add(1,2))" +
+                ",'arg3.1,arg3.2,func(arg3.3.1,arg3.3.2)'" +
+                ",arg4/(.1/)" +
+                ",arg5/,";
+            const string input = "{ \"test\": \"" + args + "\" }";
+
+            const string transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
+            var result = JsonTransformer.Transform(transformer, input);
+
+            Assert.AreEqual("{\"result\":\"arg1arg2.1,arg2.3.1#arg2.3.33arg3.1,arg3.2,func(arg3.3.1,arg3.3.2)arg4(.1)arg5,#\"}", result);
+        }
+
+        [Test]
+        public void ConsecutiveEscapedCharacters()
+        {
+            const string transformer = "{ \"result\": \"#xconcat(///),_end)\" }";
+            var result = JsonTransformer.Transform(transformer, "{}");
+            Assert.AreEqual("{\"result\":\"/)_end\"}",result);
+        }
+
+        [Test]
+        public void TestIssue59()
+        {
+            const string input = "{\"PhoneTypeToSearch\": \"iPhone\",\"Address\": [{\"City\": \"NewYork\",\"name\": \"Jim\"},{\"City\": \"NewYork\",\"name\": \"John\"}],\"people\": [{\"name\": \"Jim\",\"phoneNumbers\": [{\"type\": \"iPhone\",\"number\": \"0123-4567-8888\",\"countryPrefix\": \"34\"},{\"type\": \"work\",\"number\": \"012567-8910\"}]},{\"name\": \"John\",\"phoneNumbers\": [{\"type\": \"iPhone\",\"number\": \"0123-4562347-8888\",\"countryPrefix\": \"43\"},{\"type\": \"home\",\"number\": \"0134523-4567-8910\"}]},{\"name\": \"John\"}]}";
+
+            const string transformer = "{ \"Persons\": { \"#loop($.people)\": { \"Address\": \"#valueof(#xconcat($.Address[?,/(@.name==',#currentvalueatpath($.name),/'/)]))\" } }}";
+
+            var result = JsonTransformer.Transform(transformer, input);
+
+            Assert.AreEqual("{\"Persons\":[{\"Address\":{\"City\":\"NewYork\",\"name\":\"Jim\"}},{\"Address\":{\"City\":\"NewYork\",\"name\":\"John\"}},{\"Address\":{\"City\":\"NewYork\",\"name\":\"John\"}}]}", result);
+        }
+    }
+}

--- a/UnitTests/ArgumentsEscapeTests.cs
+++ b/UnitTests/ArgumentsEscapeTests.cs
@@ -26,15 +26,15 @@ namespace JUST.UnitTests
             Assert.AreEqual("{\"result\":\"()#\"}", result);
         }
 
-        [Test]
-        public void EscapedSingleQuotes()
-        {
-            var args = $"{EscapeChar}'{EscapeChar}'";
-            var transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
-            var result = JsonTransformer.Transform(transformer, "{}");
+        //[Test]
+        //public void EscapedSingleQuotes()
+        //{
+        //    var args = $"{EscapeChar}'{EscapeChar}'";
+        //    var transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
+        //    var result = JsonTransformer.Transform(transformer, "{}");
 
-            Assert.AreEqual("{\"result\":\"''#\"}", result);
-        }
+        //    Assert.AreEqual("{\"result\":\"''#\"}", result);
+        //}
 
         [Test]
         public void EscapedComma()
@@ -56,22 +56,22 @@ namespace JUST.UnitTests
             Assert.AreEqual($"{{\"result\":\"##\"}}", result);
         }
 
-        [Test]
-        public void QuotedArgument()
-        {
-            const string args = "'arg1,#func(arg2.1,arg2.2)'";
-            const string input = "{ \"test\": \"" + args + "\" }";
+        //[Test]
+        //public void QuotedArgument()
+        //{
+        //    const string args = "'arg1,#func(arg2.1,arg2.2)'";
+        //    const string input = "{ \"test\": \"" + args + "\" }";
 
-            const string transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
-            var result = JsonTransformer.Transform(transformer, input);
+        //    const string transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
+        //    var result = JsonTransformer.Transform(transformer, input);
 
-            Assert.AreEqual("{\"result\":\"arg1,#func(arg2.1,arg2.2)#\"}", result);
-        }
+        //    Assert.AreEqual("{\"result\":\"arg1,#func(arg2.1,arg2.2)#\"}", result);
+        //}
 
         [Test]
         public void NestedFunctionEscapedArguments()
         {
-            const string args = "#arg1,#xconcat(/#notfunc/(/), #constant_comma(),#xconcat(/,arg2.3.1,#constant_hash(),/'arg2.3.3),/,,#add(3,2))";
+            const string args = "#arg1,#xconcat(/#notfunc/(/), #constant_comma(),#xconcat(/,arg2.3.1,#constant_hash(),'arg2.3.3),/,,#add(3,2))";
             const string input = "{ \"test\": \"" + args + "\" }";
 
             const string transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
@@ -85,7 +85,7 @@ namespace JUST.UnitTests
         {
             const string args = "arg1" +
                 ",#xconcat(arg2.1,#constant_comma(),#xconcat(arg2.3.1,#constant_hash(),arg2.3.3),#add(1,2))" +
-                ",'arg3.1,arg3.2,func(arg3.3.1,arg3.3.2)'" +
+                //",'arg3.1,arg3.2,func(arg3.3.1,arg3.3.2)'" +
                 ",arg4/(.1/)" +
                 ",arg5/,";
             const string input = "{ \"test\": \"" + args + "\" }";
@@ -93,7 +93,7 @@ namespace JUST.UnitTests
             const string transformer = "{ \"result\": \"#xconcat(" + args + ",#constant_hash())\" }";
             var result = JsonTransformer.Transform(transformer, input);
 
-            Assert.AreEqual("{\"result\":\"arg1arg2.1,arg2.3.1#arg2.3.33arg3.1,arg3.2,func(arg3.3.1,arg3.3.2)arg4(.1)arg5,#\"}", result);
+            Assert.AreEqual("{\"result\":\"arg1arg2.1,arg2.3.1#arg2.3.33" /*+ "arg3.1,arg3.2,func(arg3.3.1,arg3.3.2)"*/ + "arg4(.1)arg5,#\"}", result);
         }
 
         [Test]
@@ -109,7 +109,7 @@ namespace JUST.UnitTests
         {
             const string input = "{\"PhoneTypeToSearch\": \"iPhone\",\"Address\": [{\"City\": \"NewYork\",\"name\": \"Jim\"},{\"City\": \"NewYork\",\"name\": \"John\"}],\"people\": [{\"name\": \"Jim\",\"phoneNumbers\": [{\"type\": \"iPhone\",\"number\": \"0123-4567-8888\",\"countryPrefix\": \"34\"},{\"type\": \"work\",\"number\": \"012567-8910\"}]},{\"name\": \"John\",\"phoneNumbers\": [{\"type\": \"iPhone\",\"number\": \"0123-4562347-8888\",\"countryPrefix\": \"43\"},{\"type\": \"home\",\"number\": \"0134523-4567-8910\"}]},{\"name\": \"John\"}]}";
 
-            const string transformer = "{ \"Persons\": { \"#loop($.people)\": { \"Address\": \"#valueof(#xconcat($.Address[?,/(@.name==',#currentvalueatpath($.name),/'/)]))\" } }}";
+            const string transformer = "{ \"Persons\": { \"#loop($.people)\": { \"Address\": \"#valueof(#xconcat($.Address[?,/(@.name==',#currentvalueatpath($.name),'/)]))\" } }}";
 
             var result = JsonTransformer.Transform(transformer, input);
 

--- a/UnitTests/ReadmeTests.cs
+++ b/UnitTests/ReadmeTests.cs
@@ -205,7 +205,7 @@ namespace JUST.UnitTests
         public void Issue98()
         {
             var input = "{\"procedures\": [{\"codice_prest\": \"PR-01\",\"id_paz\": \"p1\",\"id_med\": \"d2\"},{\"codice_prest\": \"PR-02\",\"id_paz\": \"p2\",\"id_med\": \"d1\"}],\"patients\": [{\"id\": \"p1\",\"name\": \"Ambrogio Rocher\"},{\"id\": \"p2\",\"name\": \"Mia Martini\"}],\"doctors\": [{\"id\": \"d1\",\"full_name\": \"Simone Rossi\"},{\"id\": \"d2\",\"full_name\": \"Davide Verdi\"}]}";
-            var transformer = "{ 	\"final\": { \"#loop($.procedures)\": { \"codice_prest\": \"#currentvalueatpath($.codice_prest)\", \"name_paz\": \"#valueof(#xconcat($.patients[?/(@.id==/',#currentvalueatpath($.id_paz),/'/)].name))\", \"id_med\": \"#valueof(#xconcat('$.doctors[?(@.id==/'',#currentvalueatpath($.id_med),/'/)].full_name))\" } }} ";
+            var transformer = "{ \"final\": { \"#loop($.procedures)\": { \"codice_prest\": \"#currentvalueatpath($.codice_prest)\", \"name_paz\": \"#valueof(#xconcat($.patients[?/(@.id==',#currentvalueatpath($.id_paz),'/)].name))\", \"id_med\": \"#valueof(#xconcat($.doctors[?/(@.id==',#currentvalueatpath($.id_med),'/)].full_name))\" } }} ";
             var context = new JUSTContext
             {
                 EvaluationMode = EvaluationMode.Strict

--- a/UnitTests/ReadmeTests.cs
+++ b/UnitTests/ReadmeTests.cs
@@ -200,5 +200,19 @@ namespace JUST.UnitTests
 
             Assert.AreEqual("{\"result\":true}", result);
         }
+
+        [Test]
+        public void Issue98()
+        {
+            var input = "{\"procedures\": [{\"codice_prest\": \"PR-01\",\"id_paz\": \"p1\",\"id_med\": \"d2\"},{\"codice_prest\": \"PR-02\",\"id_paz\": \"p2\",\"id_med\": \"d1\"}],\"patients\": [{\"id\": \"p1\",\"name\": \"Ambrogio Rocher\"},{\"id\": \"p2\",\"name\": \"Mia Martini\"}],\"doctors\": [{\"id\": \"d1\",\"full_name\": \"Simone Rossi\"},{\"id\": \"d2\",\"full_name\": \"Davide Verdi\"}]}";
+            var transformer = "{ 	\"final\": { \"#loop($.procedures)\": { \"codice_prest\": \"#currentvalueatpath($.codice_prest)\", \"name_paz\": \"#valueof(#xconcat($.patients[?/(@.id==/',#currentvalueatpath($.id_paz),/'/)].name))\", \"id_med\": \"#valueof(#xconcat('$.doctors[?(@.id==/'',#currentvalueatpath($.id_med),/'/)].full_name))\" } }} ";
+            var context = new JUSTContext
+            {
+                EvaluationMode = EvaluationMode.Strict
+            };
+            var result = JsonTransformer.Transform(transformer, input, context);
+
+            Assert.AreEqual("{\"final\":[{\"codice_prest\":\"PR-01\",\"name_paz\":\"Ambrogio Rocher\",\"id_med\":\"Davide Verdi\"},{\"codice_prest\":\"PR-02\",\"name_paz\":\"Mia Martini\",\"id_med\":\"Simone Rossi\"}]}", result);
+        }
     }
 }

--- a/UnitTests/ReadmeTests.cs
+++ b/UnitTests/ReadmeTests.cs
@@ -202,17 +202,17 @@ namespace JUST.UnitTests
         }
 
         [Test]
-        public void Issue98()
+        public void Escape()
         {
-            var input = "{\"procedures\": [{\"codice_prest\": \"PR-01\",\"id_paz\": \"p1\",\"id_med\": \"d2\"},{\"codice_prest\": \"PR-02\",\"id_paz\": \"p2\",\"id_med\": \"d1\"}],\"patients\": [{\"id\": \"p1\",\"name\": \"Ambrogio Rocher\"},{\"id\": \"p2\",\"name\": \"Mia Martini\"}],\"doctors\": [{\"id\": \"d1\",\"full_name\": \"Simone Rossi\"},{\"id\": \"d2\",\"full_name\": \"Davide Verdi\"}]}";
-            var transformer = "{ \"final\": { \"#loop($.procedures)\": { \"codice_prest\": \"#currentvalueatpath($.codice_prest)\", \"name_paz\": \"#valueof(#xconcat($.patients[?/(@.id==',#currentvalueatpath($.id_paz),'/)].name))\", \"id_med\": \"#valueof(#xconcat($.doctors[?/(@.id==',#currentvalueatpath($.id_med),'/)].full_name))\" } }} ";
+            var input = "{ \"arg\": \"some_value\" }";
+            var transformer = "{ \"sharp\": \"/#not_a_function\", \"parentheses\": \"#xconcat(func/(',#valueof($.arg),'/))\", \"comma\": \"#xconcat(func/(',#valueof($.arg),'/,'other_value'/))\" }";
             var context = new JUSTContext
             {
                 EvaluationMode = EvaluationMode.Strict
             };
             var result = JsonTransformer.Transform(transformer, input, context);
 
-            Assert.AreEqual("{\"final\":[{\"codice_prest\":\"PR-01\",\"name_paz\":\"Ambrogio Rocher\",\"id_med\":\"Davide Verdi\"},{\"codice_prest\":\"PR-02\",\"name_paz\":\"Mia Martini\",\"id_med\":\"Simone Rossi\"}]}", result);
+            Assert.AreEqual("{\"sharp\":\"#not_a_function\",\"parentheses\":\"func('some_value')\",\"comma\":\"func('some_value','other_value')\"}", result);
         }
     }
 }

--- a/UnitTests/ReadmeTests.cs
+++ b/UnitTests/ReadmeTests.cs
@@ -204,15 +204,15 @@ namespace JUST.UnitTests
         [Test]
         public void Escape()
         {
-            var input = "{ \"arg\": \"some_value\" }";
-            var transformer = "{ \"sharp\": \"/#not_a_function\", \"parentheses\": \"#xconcat(func/(',#valueof($.arg),'/))\", \"comma\": \"#xconcat(func/(',#valueof($.arg),'/,'other_value'/))\" }";
+            var input = "{ \"arg\": 1, \"arr\": [{ \"id\": 1, \"val\": 100 }, { \"id\": 2,	\"val\": 200 }] }";
+            var transformer = "{ \"sharp\": \"/#not_a_function\", \"sharp_arg\": \"#xconcat(/#not,_a_function_arg)\", \"parentheses\": \"#xconcat(func/(',#valueof($.arg),'/))\", \"comma\": \"#xconcat(func/(',#valueof($.arg),'/,'other_value'/))\", \"dynamic_expr\": \"#valueof(#xconcat($.arr[?/(@.id==,#valueof($.arg),/)].val))\" }";
             var context = new JUSTContext
             {
                 EvaluationMode = EvaluationMode.Strict
             };
             var result = JsonTransformer.Transform(transformer, input, context);
 
-            Assert.AreEqual("{\"sharp\":\"#not_a_function\",\"parentheses\":\"func('some_value')\",\"comma\":\"func('some_value','other_value')\"}", result);
+            Assert.AreEqual("{\"sharp\":\"#not_a_function\",\"sharp_arg\":\"#not_a_function_arg\",\"parentheses\":\"func('1')\",\"comma\":\"func('1','other_value')\",\"dynamic_expr\":100}", result);
         }
     }
 }


### PR DESCRIPTION
#59 #60 #98 #99 
Escape sharp (at the start of statements); curved brackets and comma when used as part of functions' arguments.
This allows to build dynamic jsonPath statements, especially useful for joins.