### PR TITLE
Added a fix to work with external file assembly that is preloaded from stream

### DIFF
--- a/JUST.Net.sln
+++ b/JUST.Net.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExternalMethods", "External
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JUST.net.UnitTests", "UnitTests\JUST.net.UnitTests.csproj", "{EEA26C5F-B8F8-40F3-8405-8887D1F712D5}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTestForExternalAssemblyBug", "UnitTestForExternalAssemblyBug\UnitTestForExternalAssemblyBug.csproj", "{ACF43DDB-7C3C-43D8-98D7-944147D61AB3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{EEA26C5F-B8F8-40F3-8405-8887D1F712D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EEA26C5F-B8F8-40F3-8405-8887D1F712D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EEA26C5F-B8F8-40F3-8405-8887D1F712D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ACF43DDB-7C3C-43D8-98D7-944147D61AB3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ACF43DDB-7C3C-43D8-98D7-944147D61AB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ACF43DDB-7C3C-43D8-98D7-944147D61AB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ACF43DDB-7C3C-43D8-98D7-944147D61AB3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/JUST.net/ReflectionHelper.cs
+++ b/JUST.net/ReflectionHelper.cs
@@ -98,9 +98,22 @@ namespace JUST
             {
                 var assemblyFileName = !assemblyName.EndsWith(".dll") ? $"{assemblyName}.dll" : assemblyName;
 
+                string GetName(Assembly a)
+                {
+                    var name = a.ManifestModule.Name;
+                    //https://docs.microsoft.com/en-us/dotnet/api/system.reflection.module.fullyqualifiedname?view=net-5.0
+                    //If the assembly for this module was loaded from a byte array then
+                    //the FullyQualifiedName and Name for the module will be: <Unknown>.
+                    if (name == "<Unknown>")
+                    {
+                        return a.ManifestModule.ScopeName;
+                    }
+
+                    return name;
+                }
                 //SingleOrDefault fails, dll registrated twice????
                 //Possible alternative to AppDomain: https://github.com/dotnet/coreclr/issues/14680
-                var assembly = assemblies.FirstOrDefault(a => a.ManifestModule.Name == assemblyFileName);
+                var assembly = assemblies.FirstOrDefault(a => GetName(a) == assemblyFileName);
                 if (assembly == null)
                 {
                     var assemblyLocation = Path.Combine(Directory.GetCurrentDirectory(), assemblyFileName);

--- a/UnitTestForExternalAssemblyBug/ExternalAssemblyBugTests.cs
+++ b/UnitTestForExternalAssemblyBug/ExternalAssemblyBugTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Extensions.DependencyModel.Resolution;
+using NUnit.Framework;
+
+namespace JUST.UnitTests
+{
+    [TestFixture, Category("CustomFunctions")]
+    public class ExternalAssemblyBugTests
+    {
+        private JUSTContext _context;
+        [SetUp]
+        public void Setup()
+        {
+            _context = new JUSTContext();
+        }
+
+        /// <summary>
+        /// We want to load external assembly to load context, use it and then unload it.
+        /// This assembly can be located anywhere (not only in bin directory)
+        ///
+        /// NOTE: THIS IS DOTNET CORE 3.1 TEST CODE
+        /// THIS PROJECT MUST NOT REFERENCE ExternalMethods to avoid having its assembly in binaries directory.
+        /// </summary>
+        [Test]
+        public void ExternalStaticMethodPreloadedFromAssembly()
+        {
+            var currentDirectory = Path.GetDirectoryName(typeof(ExternalAssemblyBugTests).Assembly.Location);
+            var searchPath = Path.GetFullPath(currentDirectory + @"\..\..\..\..\");
+
+            var assemblyFilePath = Directory.GetFiles(
+                    searchPath, "ExternalMethods.dll", SearchOption.AllDirectories).First();
+
+            var loadContext = new AssemblyLoadContext(name: Guid.NewGuid().ToString(), isCollectible: true);
+
+            {
+                // read the file and release it immediately (do not keep handle)
+                using var stream = new FileStream(assemblyFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                // alternatively can be used the line below:
+                //using var stream = new MemoryStream(File.ReadAllBytes(assemblyFilePath));
+                var loadedAssembly = loadContext.LoadFromStream(stream);
+
+                Assert.AreEqual("<Unknown>", loadedAssembly.ManifestModule.FullyQualifiedName);
+                Assert.AreEqual("<Unknown>", loadedAssembly.ManifestModule.Name);
+                Assert.AreEqual("ExternalMethods.dll", loadedAssembly.ManifestModule.ScopeName);
+                // it seems that ScopeName is only reliable information in this case
+            }
+            const string input = "{ }";
+            const string transformer = "{ \"result\": \"#StaticMethod()\" }";
+
+            _context.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "StaticMethod");
+            var result = new JsonTransformer(_context).Transform(transformer, input);
+
+            Assert.AreEqual("{\"result\":\"External Static\"}", result);
+
+            _context.ClearCustomFunctionRegistrations();
+            loadContext.Unload();
+        }
+
+    }
+}

--- a/UnitTestForExternalAssemblyBug/UnitTestForExternalAssemblyBug.csproj
+++ b/UnitTestForExternalAssemblyBug/UnitTestForExternalAssemblyBug.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <RootNamespace>JUST.UnitTests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\JUST.net\JUST.net.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
New dotnet allows us to use [AssemblyLoadContext](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.loader.assemblyloadcontext.-ctor?view=net-5.0#System_Runtime_Loader_AssemblyLoadContext__ctor_System_String_System_Boolean_) to temporarily load and unload assemblies. For example, it is possible first to read assembly into memory and then load it into [context as stream](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.loader.assemblyloadcontext.loadfromstream?view=net-5.0) in order not to lock the file on disk. Or simply use [Assembly.Load](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.load?view=net-5.0#System_Reflection_Assembly_Load_System_Byte___) from byte array. Such assemblies have ManifestModule.Name and ManifestModule.FullyQualifiedName defined as "\<Unknown\>" (see https://docs.microsoft.com/en-us/dotnet/api/system.reflection.module.fullyqualifiedname?view=net-5.0). In this case the only reliable information is in ManifestModule.ScopeName. To make this work in JUST.net we need to change the following line in JUST.net/ReflectionHelper.cs
```
var assembly = assemblies.FirstOrDefault(a => a.ManifestModule.Name == assemblyFileName);
```
to use ```ManifestModule.ScopeName``` in case of ```<Unknown>``` name.