### PR TITLE
Also transform values, not only objects and arrays 

### DIFF
--- a/UnitTests/SimpleTransformTests.cs
+++ b/UnitTests/SimpleTransformTests.cs
@@ -1,0 +1,64 @@
+﻿using NUnit.Framework;
+
+namespace JUST.UnitTests
+{
+    [TestFixture]
+    public class SimpleTransformTests
+    {
+        [Test]
+        public void String()
+        {
+            var input = "{\"Food\": {\"Desserts\": {\"item\": [{\"name\": \"carrot cake\",\"price\": 5},{\"name\": \"ice cream\",\"price\": 10}]}}}";
+            var transformer = "\"abc\"";
+            var context = new JUSTContext
+            {
+                EvaluationMode = EvaluationMode.Strict
+            };
+            var result = new JsonTransformer(context).Transform(transformer, input);
+
+            Assert.AreEqual("\"abc\"", result);
+        }
+
+        [Test]
+        public void StringWithFunction()
+        {
+            var input = "{\"Food\": {\"Desserts\": {\"item\": [{\"name\": \"carrot cake\",\"price\": 5},{\"name\": \"ice cream\",\"price\": 10}]}}}";
+            var transformer = "\"#valueof($.Food.Desserts.item)\"";
+            var context = new JUSTContext
+            {
+                EvaluationMode = EvaluationMode.Strict
+            };
+            var result = new JsonTransformer(context).Transform(transformer, input);
+
+            Assert.AreEqual("[{\"name\":\"carrot cake\",\"price\":5},{\"name\":\"ice cream\",\"price\":10}]", result);
+        }
+
+        [Test]
+        public void ReturnInput()
+        {
+            var input = "{\"Food\": {\"Desserts\": {\"item\": [{\"name\": \"carrot cake\",\"price\": 5},{\"name\": \"ice cream\",\"price\": 10}]}}}";
+            var transformer = "\"#valueof($)\"";
+            var context = new JUSTContext
+            {
+                EvaluationMode = EvaluationMode.Strict
+            };
+            var result = new JsonTransformer(context).Transform(transformer, input);
+
+            Assert.AreEqual("{\"Food\":{\"Desserts\":{\"item\":[{\"name\":\"carrot cake\",\"price\":5},{\"name\":\"ice cream\",\"price\":10}]}}}", result);
+        }
+
+        [Test]
+        public void SimpleArrayElement()
+        {
+            var input = "{\"Food\": {\"Desserts\": {\"item\": [{\"name\": \"carrot cake\",\"price\": 5},{\"name\": \"ice cream\",\"price\": 10}]}}}";
+            var transformer = "[ \"#valueof($.Food.Desserts.item[*].name)\" ]";
+            var context = new JUSTContext
+            {
+                EvaluationMode = EvaluationMode.Strict
+            };
+            var result = new JsonTransformer(context).Transform(transformer, input);
+
+            Assert.AreEqual("[\"carrot cake\",\"ice cream\"]", result);
+        }
+    }
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 
 trigger:
-- develop
+- master
 
 pool:
   vmImage: 'windows-latest'


### PR DESCRIPTION
#143 #161 
Allow transforms to be a simple value (ex: a string), instead of an object or an array.
Return the input unmodified is now possible.