### PR TITLE
Fix schema validator

### DIFF
--- a/JUST.net/JsonValidator.cs
+++ b/JUST.net/JsonValidator.cs
@@ -2,6 +2,7 @@
 using NJsonSchema.Validation;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace JUST
@@ -31,7 +32,7 @@ namespace JUST
 
         public async Task Validate()
         {
-            List<string> errors = null;
+            List<string> errors = new List<string>();
 
             if (!string.IsNullOrEmpty(schemaNoPrefix))
             {
@@ -45,7 +46,7 @@ namespace JUST
                 }
             }
 
-            if (errors != null)
+            if (errors.Count > 0)
             {
                 throw new Exception(string.Join(" AND ", errors.ToArray()));
             }

--- a/UnitTests/JsonValidatorTests.cs
+++ b/UnitTests/JsonValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
+using System.Threading.Tasks;
 
 namespace JUST.UnitTests
 {
@@ -7,14 +8,14 @@ namespace JUST.UnitTests
     public class JsonValidatorTests
     {
         [Test]
-        public void SchemaOk()
+        public async Task SchemaOk()
         {
             const string input = "{ \"id\": 1, \"name\": \"Person 1\", \"gender\": \"M\" }";
             const string schema = "{ \"$schema\": \"https://json-schema.org/draft/2020-12/schema\", \"$id\": \"https://just.net\", \"title\": \"JUST Test\", \"description\": \"JUST test schema\", \"type\": \"object\", \"properties\": { \"id\": { \"description\": \"JUST Test\", \"type\": \"integer\" } }, \"required\": [ \"id\" ]}";
             var v = new JsonValidator(input);
             v.AddSchema(null, schema);
 
-            v.Validate();
+            await v.Validate();
 
             Assert.Pass();
         }


### PR DESCRIPTION
Although a schema could validate a Json with errors, since the call to validate was async, the test was passing.