### PR TITLE
Bug when custom functions' first parameter is null

### DIFF
--- a/ExternalMethods/ExternalClass.cs
+++ b/ExternalMethods/ExternalClass.cs
@@ -33,5 +33,10 @@ namespace ExternalMethods
         {
             return val?.ToString();
         }
+
+        public object CheckNullParameters(object val1, object val2)
+        {
+            return val1 ?? val2;
+        }
     }
 }

--- a/JUST.net/ReflectionHelper.cs
+++ b/JUST.net/ReflectionHelper.cs
@@ -78,7 +78,7 @@ namespace JUST
             var assembly = GetAssembly(isAssemblyDefined, assemblyName, namespc, methodName);
             if (assembly != null)
             {
-                return Caller<T>(assembly, namespc, methodName, FilterParameters(parameters), true, context);
+                return Caller<T>(assembly, namespc, methodName, parameters, true, context);
             }
 
             throw new MissingMethodException((assemblyName != null ? $"{assemblyName}." : string.Empty) + $"{namespc}.{methodName}");
@@ -147,19 +147,6 @@ namespace JUST
                 }
             }
             return null;
-        }
-
-        private static object[] FilterParameters(object[] parameters)
-        {
-            if (string.IsNullOrEmpty(parameters[0]?.ToString() ?? string.Empty))
-            {
-                parameters = parameters.Skip(1).ToArray();
-            }
-            if (parameters.Length > 0 && parameters.Last().ToString() == "{}")
-            {
-                parameters = parameters.Take(parameters.Length - 1).ToArray();
-            }
-            return parameters;
         }
 
         internal static Type GetType(JTokenType jType)

--- a/UnitTests/CustomFunctionsTest.cs
+++ b/UnitTests/CustomFunctionsTest.cs
@@ -17,5 +17,45 @@ namespace JUST.UnitTests
                 (new JsonTransformer().Transform(JObject.Parse(transformer), JObject.Parse(inputSpecial)));
             Assert.AreEqual("{\"Seasons\":[[[[\"2017\"],[\"40\"],[\"20\"],[\"25\"],[\"10\"]],[[\"2018\"],[\"40\"],[\"20\"],[\"25\"],[\"10\"]],[[\"2019\"],[\"40\"],[\"20\"],[\"25\"],[\"10\"]]]]}", result);
         }
+
+        [Test]
+        public void RegisteredCustomFunction()
+        {
+            const string input = "{ \"ExcessQuoteAmendments\": [{ \"Name\": \"test_name\", \"Attributes\": [{ \"CoverageDataType\": \"test_coverage\", \"Value\": \"test_value\"}, { }] }]";
+            string transformer = "{ \"ExcessFormsList\": { \"#loop($.ExcessQuoteAmendments)\": { \"AttributesList\": { \"#loop($.Attributes)\": { \"Value\":\"#aliascustomfunction(#currentvalueatpath($.Value), #currentvalueatpath($.CoverageDataType))\" }}}}}";
+            var context = new JUSTContext();
+            context.RegisterCustomFunction("ExternalMethods", "ExternalMethods.ExternalClass", "CheckNullParameters", "aliascustomfunction");
+
+            var actual = new JsonTransformer(context).Transform(transformer, input);
+
+            Assert.AreEqual("{\"ExcessFormsList\":[{\"AttributesList\":[{\"Value\":\"test_value\"},{\"Value\":null}]}]}", actual);
+        }
+
+        [Test]
+        public void AssemblyDefined()
+        {
+            const string input = "{ \"ExcessQuoteAmendments\": [{ \"Name\": \"test_name\", \"Attributes\": [{ \"CoverageDataType\": \"test_coverage\", \"Value\": \"test_value\"}, { }] }]";
+            string transformer = "{ \"ExcessFormsList\": { \"#loop($.ExcessQuoteAmendments)\": { \"AttributesList\": { \"#loop($.Attributes)\": { \"Value\":\"#ExternalMethods::ExternalMethods.ExternalClass::CheckNullParameters(#currentvalueatpath($.Value), #currentvalueatpath($.CoverageDataType))\" }}}}}";
+
+            var actual = new JsonTransformer().Transform(transformer, input);
+
+            Assert.AreEqual("{\"ExcessFormsList\":[{\"AttributesList\":[{\"Value\":\"test_value\"},{\"Value\":null}]}]}", actual);
+        }
+
+        [Test]
+        public void WithoutAssembly()
+        {
+            const string input = "{ \"ExcessQuoteAmendments\": [{ \"Name\": \"test_name\", \"Attributes\": [{ \"CoverageDataType\": \"test_coverage\", \"Value\": \"test_value\"}, { }] }]";
+            string transformer = "{ \"ExcessFormsList\": { \"#loop($.ExcessQuoteAmendments)\": { \"AttributesList\": { \"#loop($.Attributes)\": { \"Value\":\"#JUST.UnitTests.CustomFunctionsTests::CheckNullParameters(#currentvalueatpath($.Value), #currentvalueatpath($.CoverageDataType))\" }}}}}";
+
+            var actual = new JsonTransformer().Transform(transformer, input);
+
+            Assert.AreEqual("{\"ExcessFormsList\":[{\"AttributesList\":[{\"Value\":\"test_value\"},{\"Value\":null}]}]}", actual);
+        }
+
+        public object CheckNullParameters(object val1, object val2)
+        {
+            return val1 ?? val2;
+        }
     }
 }


### PR DESCRIPTION
First parameter was removed if it was null, for custom functions
#187 