### PR TITLE
Fix/memory usage

### DIFF
--- a/JUST.net/ExpressionHelper.cs
+++ b/JUST.net/ExpressionHelper.cs
@@ -9,7 +9,7 @@ namespace JUST
 
         internal static bool TryParseFunctionNameAndArguments(string input, out string functionName, out string arguments)
         {
-            var match = new Regex(FunctionAndArgumentsRegex).Match(input);
+            var match = Regex.Match(input, FunctionAndArgumentsRegex, RegexOptions.Compiled);
             functionName = match.Success ? match.Groups[1].Value : input;
             arguments = match.Success ? match.Groups[2].Value : null;
             return match.Success;

--- a/JUST.net/JsonTransformer.cs
+++ b/JUST.net/JsonTransformer.cs
@@ -902,12 +902,12 @@ namespace JUST
             var contextInput = Context.Input;
             var input = JToken.Parse(Transform(parameters[0].ToString(), contextInput.ToString()));
             Context.Input = input;
-            if (parameters[1].ToString().Trim().Trim('\'').StartsWith('{'))
+            if (parameters[1].ToString().Trim().Trim('\'').StartsWith("{"))
             {
                 var jobj = JObject.Parse(parameters[1].ToString().Trim().Trim('\''));
                 output = new JsonTransformer(Context).Transform(jobj, input);
             }
-            else if (parameters[1].ToString().Trim().Trim('\'').StartsWith('['))
+            else if (parameters[1].ToString().Trim().Trim('\'').StartsWith("["))
             {
                 var jarr = JArray.Parse(parameters[1].ToString().Trim().Trim('\''));
                 output = new JsonTransformer(Context).Transform(jarr, input);


### PR DESCRIPTION
Hi Team,

We are using Just.net heavily on our current project to transform JSON responses from underlying REST services. In some cases this responses are large and this causes performance and high memory usage issues, especially in concurrent environment. 

Bellow are provided benchmark results for `LargeInput()` test method in **LoadTests.cs**: 
![image](https://github.com/WorkMaze/JUST.net/assets/149437517/5378fedc-b8ee-4db3-8afe-aea0bb624e21)

This can be improved with single line of code by using static `Regex.Match` method instead of instance level new `Regex(pattern).Match(input)` in **ExpressionHelper.cs**.

Benchmark results when `Regex.Match` is used:
![image](https://github.com/WorkMaze/JUST.net/assets/149437517/9c837ac2-616c-4af0-9583-a7bdfc2a76c4)

PR also contains compilation fix for StartsWith method which is used with char argument.
